### PR TITLE
Handle file restart events

### DIFF
--- a/src/Logonaut.UI/ViewModels/MainViewModel.LogLoading.cs
+++ b/src/Logonaut.UI/ViewModels/MainViewModel.LogLoading.cs
@@ -48,6 +48,14 @@ public partial class MainViewModel : ObservableObject, IDisposable, ICommandExec
         }, null);
     }
 
+    // Handles the SourceRestartDetected event from the internal TabViewModel.
+    // In the single-tab setup, simply reload the specified file in the same tab.
+    private void HandleInternalTabSourceRestart(TabViewModel snapshotTab, string restartedFilePath)
+    {
+        Debug.WriteLine($"{DateTime.Now:HH:mm:ss.fff} MainViewModel.HandleInternalTabSourceRestart: '{restartedFilePath}'");
+        _uiContext.Post(_ => _ = LoadLogFileCoreAsync(restartedFilePath), null);
+    }
+
     /*
      * Core logic for loading a log file from a given path.
      * This method reconfigures and activates the internal TabViewModel to handle the file.

--- a/src/Logonaut.UI/ViewModels/MainViewModel.cs
+++ b/src/Logonaut.UI/ViewModels/MainViewModel.cs
@@ -103,10 +103,12 @@ public partial class MainViewModel : ObservableObject, IDisposable, ICommandExec
         _internalTabViewModel.RequestScrollToLineIndex += (s, e) => RequestGlobalScrollToLineIndex?.Invoke(s, e);
         _internalTabViewModel.PropertyChanged += InternalTabViewModel_PropertyChanged;
         _internalTabViewModel.FilteredLinesUpdated += InternalTabViewModel_FilteredLinesUpdated;
+        _internalTabViewModel.SourceRestartDetected += HandleInternalTabSourceRestart;
         _disposables.Add(Disposable.Create(() =>
             {
                 _internalTabViewModel.PropertyChanged -= InternalTabViewModel_PropertyChanged;
                 _internalTabViewModel.FilteredLinesUpdated -= InternalTabViewModel_FilteredLinesUpdated;
+                _internalTabViewModel.SourceRestartDetected -= HandleInternalTabSourceRestart;
             }));
 
         // STEP 2: Now load settings, which will set ActiveFilterProfile and trigger its OnChanged ---


### PR DESCRIPTION
## Summary
- reload the log file when the source signals a reset
- hook up `SourceRestartDetected` events on the internal tab

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build Logonaut.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test --no-build` *(fails: test assemblies invalid for current environment)*

------
https://chatgpt.com/codex/tasks/task_e_684ec837b2b4832c91f21c306860bafb