### PR TITLE
Enable undoable tab header renaming

### DIFF
--- a/src/Logonaut.UI/Commands/ChangeTabHeaderAction.cs
+++ b/src/Logonaut.UI/Commands/ChangeTabHeaderAction.cs
@@ -1,0 +1,33 @@
+using Logonaut.UI.ViewModels;
+using Logonaut.Core.Commands;
+
+namespace Logonaut.UI.Commands;
+
+/// <summary>
+/// Action to change the header of a TabViewModel.
+/// </summary>
+public class ChangeTabHeaderAction : IUndoableAction
+{
+    private readonly TabViewModel _tabViewModel;
+    private readonly string _oldHeader;
+    private readonly string _newHeader;
+
+    public string Description => $"Change tab header from '{_oldHeader}' to '{_newHeader}'";
+
+    public ChangeTabHeaderAction(TabViewModel tabViewModel, string oldHeader, string newHeader)
+    {
+        _tabViewModel = tabViewModel;
+        _oldHeader = oldHeader;
+        _newHeader = newHeader;
+    }
+
+    public void Execute()
+    {
+        _tabViewModel.Header = _newHeader;
+    }
+
+    public void Undo()
+    {
+        _tabViewModel.Header = _oldHeader;
+    }
+}

--- a/src/Logonaut.UI/ViewModels/TabViewModel.cs
+++ b/src/Logonaut.UI/ViewModels/TabViewModel.cs
@@ -3,7 +3,8 @@ using CommunityToolkit.Mvvm.Input;
 using Logonaut.Common;
 using Logonaut.Core;
 using Logonaut.Filters;
-using Logonaut.Core.Commands; 
+using Logonaut.Core.Commands;
+using Logonaut.UI.Commands;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -101,6 +102,7 @@ public partial class TabViewModel : ObservableObject, IDisposable
     // --- Header Editing State ---
     [ObservableProperty] private bool _isEditingHeader;
     [ObservableProperty] private string _editingHeaderName = string.Empty;
+    private string? _headerBeforeEdit;
 
     // --- Header Editing Commands ---
     public IRelayCommand BeginEditHeaderCommand { get; }
@@ -577,6 +579,7 @@ public partial class TabViewModel : ObservableObject, IDisposable
     {
         Debug.WriteLine($"--> BeginEditHeader for '{Header}'");
         EditingHeaderName = Header;
+        _headerBeforeEdit = Header;
         IsEditingHeader = true;
     }
 
@@ -586,7 +589,8 @@ public partial class TabViewModel : ObservableObject, IDisposable
         {
             if (!string.IsNullOrWhiteSpace(EditingHeaderName) && Header != EditingHeaderName)
             {
-                Header = EditingHeaderName; // This will trigger OnHeaderChanged
+                var action = new ChangeTabHeaderAction(this, _headerBeforeEdit ?? Header, EditingHeaderName);
+                _globalCommandExecutor.Execute(action);
             }
             IsEditingHeader = false;
         }
@@ -595,6 +599,7 @@ public partial class TabViewModel : ObservableObject, IDisposable
     private void ExecuteCancelEditHeader()
     {
         IsEditingHeader = false;
+        EditingHeaderName = Header; // Revert any changes in the editing textbox
     }
 
     public void ApplyFiltersFromProfile(IEnumerable<FilterProfileViewModel> availableProfiles, int globalContextLines)

--- a/tests/Logonaut.UI.Tests/TabViewModel_HeaderEditTests.cs
+++ b/tests/Logonaut.UI.Tests/TabViewModel_HeaderEditTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Logonaut.UI.ViewModels;
+using Logonaut.UI.Commands;
+using Logonaut.TestUtils;
+using Logonaut.Core;
+
+namespace Logonaut.UI.Tests.ViewModels;
+
+[TestClass] public class TabViewModel_HeaderEditTests
+{
+    private MockCommandExecutor _executor = null!;
+    private MockLogSourceProvider _provider = null!;
+    private TabViewModel _viewModel = null!;
+    private ImmediateSynchronizationContext _context = null!;
+
+    [TestInitialize] public void TestInitialize()
+    {
+        _executor = new MockCommandExecutor();
+        _provider = new MockLogSourceProvider();
+        _context = new ImmediateSynchronizationContext();
+        _viewModel = new TabViewModel("Tab1", "Default", SourceType.Pasted, "id", _provider, _executor, _context);
+    }
+
+    [TestMethod] public void EndEditHeaderCommand_ShouldExecuteChangeAction_WhenNameChanged()
+    {
+        // Arrange
+        _viewModel.BeginEditHeaderCommand.Execute(null);
+        _viewModel.EditingHeaderName = "NewName";
+        _executor.Reset();
+
+        // Act
+        _viewModel.EndEditHeaderCommand.Execute(null);
+
+        // Assert
+        Assert.IsFalse(_viewModel.IsEditingHeader);
+        Assert.IsInstanceOfType(_executor.LastExecutedAction, typeof(ChangeTabHeaderAction));
+        Assert.AreEqual("NewName", _viewModel.Header);
+    }
+
+    [TestMethod] public void EndEditHeaderCommand_ShouldNotExecuteAction_WhenNameUnchanged()
+    {
+        // Arrange
+        _viewModel.BeginEditHeaderCommand.Execute(null);
+        _executor.Reset();
+
+        // Act
+        _viewModel.EndEditHeaderCommand.Execute(null);
+
+        // Assert
+        Assert.IsFalse(_viewModel.IsEditingHeader);
+        Assert.IsNull(_executor.LastExecutedAction);
+        Assert.AreEqual("Tab1", _viewModel.Header);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ChangeTabHeaderAction` for undo/redo integration
- hook tab header editing commands to use the new action
- expose header editing state reset on cancel
- add unit tests for tab header renaming

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857958fe980832cb614b080ef6f5fb3